### PR TITLE
Select car menu bug

### DIFF
--- a/Assets/Scripts/UI/SelectCarMainMenu.cs
+++ b/Assets/Scripts/UI/SelectCarMainMenu.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using TMPro;
@@ -60,6 +61,14 @@ public class SelectCarMainMenu : MonoBehaviour
         GetCarStats();
     }
     
+    /// <summary>
+    /// Destroys car prefab on menu close
+    /// </summary>
+    private void OnDisable()
+    {
+        Destroy(currentPrefab);
+    }
+
     /// <summary>
     /// Gets Nft car stats from chain
     /// </summary>


### PR DESCRIPTION
Instantiated car prefab was staying there on menu change causing visual glitches, fixed by destroying it on menu close.